### PR TITLE
Use Emacs's built-in time functionality

### DIFF
--- a/perkeep.el
+++ b/perkeep.el
@@ -596,8 +596,7 @@ this function."
 
 ;; (perkeep--now)
 (defun perkeep--now ()
-  ;; TODO use correct milliseconds instead of 000
-  (substring (shell-command-to-string "date -u +%Y-%m-%dT%H:%M:%S.000Z") 0 -1))
+  (format-time-string "%FT%T.%3NZ" nil "UTC0"))
 
 (defvar perkeep-sourced-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
Someone on IRC pointed out this package, and I noticed a small place I might be able to help: this changes `perkeep--now` from shelling out to `date` and instead uses built-in Emacs time functions.

I tested this expression against both a recent build from master as well as Emacs 26.1 (both on macOS) and it seems to work.

I also inserted the milliseconds while I was in here, as per the comment.

`README` may now want to be modified, but since this PR removes the only requirement, I didn't know how you'd want that file to be edited, so I figured I'd leave it up to you.